### PR TITLE
Added Diagnostic and Diagnosticf.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TESTS = auto check known failing writer
+TESTS = auto check diagnostic known failing writer
 GOPATH = $(CURDIR)/gopath
 
 .PHONY: $(TESTS)

--- a/tap.go
+++ b/tap.go
@@ -111,3 +111,13 @@ func (t *T) Count() int {
 func (t *T) AutoPlan() {
 	t.printf("1..%d\n", t.Count())
 }
+
+// Diagnostic generates a diagnostic from the message.
+func (t *T) Diagnostic(message string) {
+	t.printf("# %s\n", message)
+}
+
+// Diagnosticf generates a diagnostic from the format string and arguments.
+func (t *T) Diagnosticf(format string, a ...interface{}) {
+	t.printf("# "+format+"\n", a...)
+}

--- a/tap.go
+++ b/tap.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 import "testing/quick"
 
@@ -112,12 +113,18 @@ func (t *T) AutoPlan() {
 	t.printf("1..%d\n", t.Count())
 }
 
-// Diagnostic generates a diagnostic from the message.
-func (t *T) Diagnostic(message string) {
-	t.printf("# %s\n", message)
+func escapeNewlines(s string) string {
+	return strings.Replace(strings.TrimRight(s, "\n"), "\n", "\n# ", -1)
 }
 
-// Diagnosticf generates a diagnostic from the format string and arguments.
+// Diagnostic generates a diagnostic from the message,
+// which may span multiple lines.
+func (t *T) Diagnostic(message string) {
+	t.printf("# %s\n", escapeNewlines(message))
+}
+
+// Diagnosticf generates a diagnostic from the format string and arguments,
+// which may span multiple lines.
 func (t *T) Diagnosticf(format string, a ...interface{}) {
-	t.printf("# "+format+"\n", a...)
+	t.printf("# "+escapeNewlines(format)+"\n", a...)
 }

--- a/test/diagnostic/main.go
+++ b/test/diagnostic/main.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/mndrix/tap-go"
+
+func main() {
+	t := tap.New()
+	t.Header(1)
+	t.Diagnostic("expecting all to be well")
+	t.Diagnosticf("here's some perfectly magical output: %d %s 0x%X.", 6, "abracadabra", 28)
+	t.Pass("all good")
+}

--- a/test/diagnostic/main.go
+++ b/test/diagnostic/main.go
@@ -7,5 +7,7 @@ func main() {
 	t.Header(1)
 	t.Diagnostic("expecting all to be well")
 	t.Diagnosticf("here's some perfectly magical output: %d %s 0x%X.", 6, "abracadabra", 28)
+	t.Diagnostic("some\nmultiline\ntext\n")
+	t.Diagnosticf("%d lines\n%s multiline\ntext", 3, "more")
 	t.Pass("all good")
 }


### PR DESCRIPTION
Resolves #3.

These produce diagnostic output, as defined by the TAP spec.

I thought it was worth having both, as otherwise my code tends to be littered with fmt.Sprintf() inside t.Diagnostic().