### PR TITLE
test/failing: Wrap failing tests in another harness

### DIFF
--- a/test/failing/main.go
+++ b/test/failing/main.go
@@ -1,10 +1,25 @@
 package main
 
-import "github.com/mndrix/tap-go"
+import (
+	"bytes"
+
+	"github.com/mndrix/tap-go"
+)
 
 func main() {
-	t := tap.New()
-	t.Header(2)
-	t.Ok(false, "first test")
-	t.Fail("second test")
+	t1 := tap.New()
+	t1.Header(2)
+
+	buf := new(bytes.Buffer)
+	t2 := tap.New()
+	t2.Writer = buf
+	t2.Header(2)
+
+	buf.Reset()
+	t2.Ok(false, "first test")
+	t1.Ok(buf.String() == "not ok 1 - first test\n", "Ok(false, ...) produces appropriate output")
+
+	buf.Reset()
+	t2.Fail("second test")
+	t1.Ok(buf.String() == "not ok 2 - second test\n", "Fail(...) produces appropriate output")
 }


### PR DESCRIPTION
Use two harnesses, where the inner harness has failing tests and
writes to a buffer.  The outer harness checks that buffer to ensure
the output is appropriate.  This lets the whole test suite pass:

    $ make
    ...
    All tests successful.
    Files=6, Tests=15,  0 wallclock secs ( 0.05 usr  0.01 sys +  0.00 cusr  0.01 csys =  0.07 CPU)
    Result: PASS

while before this commit it failed:

    $ make
    ...
    Test Summary Report
    -------------------
    test/failing/test   (Wstat: 0 Tests: 2 Failed: 2)
      Failed tests:  1-2
    Files=6, Tests=15,  0 wallclock secs ( 0.05 usr +  0.00 sys =  0.05 CPU)
    Result: FAIL
    Makefile:7: recipe for target 'all' failed
    make: *** [all] Error 1