### PR TITLE
Add T.TODO and T.Skip directives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TESTS = auto check diagnostic failing known skip writer
+TESTS = auto check diagnostic failing known skip todo writer
 GOPATH = $(CURDIR)/gopath
 
 .PHONY: $(TESTS)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TESTS = auto check diagnostic known failing writer
+TESTS = auto check diagnostic failing known skip writer
 GOPATH = $(CURDIR)/gopath
 
 .PHONY: $(TESTS)

--- a/tap.go
+++ b/tap.go
@@ -117,6 +117,14 @@ func escapeNewlines(s string) string {
 	return strings.Replace(strings.TrimRight(s, "\n"), "\n", "\n# ", -1)
 }
 
+// Skip indicates that a test has been skipped.
+func (t *T) Skip(count int, description string) {
+	for i := 0; i < count; i++ {
+		t.printf("ok %d # SKIP %s\n", t.nextTestNumber, description)
+		t.nextTestNumber++
+	}
+}
+
 // Diagnostic generates a diagnostic from the message,
 // which may span multiple lines.
 func (t *T) Diagnostic(message string) {

--- a/test/skip/main.go
+++ b/test/skip/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	tap "github.com/mndrix/tap-go"
+)
+
+func main() {
+	// collect output for comparison later
+	buf := new(bytes.Buffer)
+	t := tap.New()
+	t.Writer = io.MultiWriter(os.Stdout, buf)
+
+	t.Header(4)
+	t.Skip(1, "insufficient flogiston pressure")
+	t.Skip(2, "no /sys directory")
+
+	got := buf.String()
+	t.Ok(got == expected, "skip gave expected output")
+}
+
+const expected = `TAP version 13
+1..4
+ok 1 # SKIP insufficient flogiston pressure
+ok 2 # SKIP no /sys directory
+ok 3 # SKIP no /sys directory
+`

--- a/test/todo/main.go
+++ b/test/todo/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	tap "github.com/mndrix/tap-go"
+)
+
+func main() {
+	// collect output for comparison later
+	buf := new(bytes.Buffer)
+	t := tap.New()
+	t.Writer = io.MultiWriter(os.Stdout, buf)
+
+	t.Header(6)
+	t.TODO = true
+	t.Ok(false, "using Ok(false, ...) in TODO mode")
+	t.Fail("using Fail(...) in TODO mode")
+	t.TODO = false
+	t.Ok(true, "using Ok(false, ...) after leaving TODO mode")
+
+	t.Todo().Fail("using Fail(...) in TODO mode with method chaining")
+	t.Pass("using Pass(...) after Todo method chaining")
+
+	got := buf.String()
+	t.Ok(got == expected, "TODO gave expected output")
+}
+
+const expected = `TAP version 13
+1..6
+not ok 1 # TODO using Ok(false, ...) in TODO mode
+not ok 2 # TODO using Fail(...) in TODO mode
+ok 3 - using Ok(false, ...) after leaving TODO mode
+not ok 4 # TODO using Fail(...) in TODO mode with method chaining
+ok 5 - using Pass(...) after Todo method chaining
+`


### PR DESCRIPTION
[The spec wants these without hyphens][1], so we can't generate them without a new API.  You could have `T.Directive(test bool, directive, description string)`, but it seems more convenient to have a separate method for each case.

[1]: http://testanything.org/tap-version-13-specification.html#directives