### PR TITLE
Add YAML() for generating YAML blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TESTS = auto check diagnostic failing known skip todo writer
+TESTS = auto check diagnostic failing known skip todo writer yaml
 GOPATH = $(CURDIR)/gopath
 
 .PHONY: $(TESTS)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TESTS = auto check diagnostic failing known skip todo writer yaml
-GOPATH = $(CURDIR)/gopath
+GOPATH ?= $(CURDIR)/gopath
 
 .PHONY: $(TESTS)
 
@@ -9,8 +9,8 @@ all: $(foreach t,$(TESTS),test/$(t)/test)
 clean:
 	rm -f test/*/test
 
-test/%/test: test/%/main.go tap.go
-	go build -o $@ $<
+test/%/test: test/%/*.go tap.go yaml_json.go yaml_yaml.go
+	go build -o $@ -tags yaml ./test/$*
 
 $(TESTS): %: test/%/test
 	prove -v -e '' test/$@/test

--- a/tap.go
+++ b/tap.go
@@ -21,6 +21,7 @@
 package tap // import "github.com/mndrix/tap-go"
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -150,4 +151,16 @@ func (t *T) Diagnostic(message string) {
 // which may span multiple lines.
 func (t *T) Diagnosticf(format string, a ...interface{}) {
 	t.printf("# "+escapeNewlines(format)+"\n", a...)
+}
+
+// YAML generates a YAML block from the message.
+func (t *T) YAML(message interface{}) error {
+	bytes, err := json.MarshalIndent(message, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	t.printf("  ---\n  ")
+	t.printf(string(bytes))
+	t.printf("\n  ...\n")
+	return nil
 }

--- a/tap.go
+++ b/tap.go
@@ -21,7 +21,6 @@
 package tap // import "github.com/mndrix/tap-go"
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -155,12 +154,12 @@ func (t *T) Diagnosticf(format string, a ...interface{}) {
 
 // YAML generates a YAML block from the message.
 func (t *T) YAML(message interface{}) error {
-	bytes, err := json.MarshalIndent(message, "  ", "  ")
+	bytes, err := yaml(message, "  ")
 	if err != nil {
 		return err
 	}
 	t.printf("  ---\n  ")
 	t.printf(string(bytes))
-	t.printf("\n  ...\n")
+	t.printf("  ...\n")
 	return nil
 }

--- a/test/yaml/json.go
+++ b/test/yaml/json.go
@@ -1,0 +1,14 @@
+// +build !yaml
+
+package main
+
+const expected = `TAP version 13
+1..2
+ok 1 - test for anchoring the YAML block
+  ---
+  {
+    "code": 3,
+    "message": "testing YAML blocks"
+  }
+  ...
+`

--- a/test/yaml/main.go
+++ b/test/yaml/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	tap "github.com/mndrix/tap-go"
+)
+
+func main() {
+	// collect output for comparison later
+	buf := new(bytes.Buffer)
+	t := tap.New()
+	t.Writer = io.MultiWriter(os.Stdout, buf)
+
+	t.Header(2)
+	t.Pass("test for anchoring the YAML block")
+	message := map[string]interface{}{
+		"message": "testing YAML blocks",
+		"code":    3,
+	}
+	t.YAML(message)
+	got := buf.String()
+	t.Ok(got == expected, "diagnostics gave expected output")
+}
+
+const expected = `TAP version 13
+1..2
+ok 1 - test for anchoring the YAML block
+  ---
+  {
+    "code": 3,
+    "message": "testing YAML blocks"
+  }
+  ...
+`

--- a/test/yaml/main.go
+++ b/test/yaml/main.go
@@ -24,14 +24,3 @@ func main() {
 	got := buf.String()
 	t.Ok(got == expected, "diagnostics gave expected output")
 }
-
-const expected = `TAP version 13
-1..2
-ok 1 - test for anchoring the YAML block
-  ---
-  {
-    "code": 3,
-    "message": "testing YAML blocks"
-  }
-  ...
-`

--- a/test/yaml/yaml.go
+++ b/test/yaml/yaml.go
@@ -1,0 +1,12 @@
+// +build yaml
+
+package main
+
+const expected = `TAP version 13
+1..2
+ok 1 - test for anchoring the YAML block
+  ---
+  code: 3
+  message: testing YAML blocks
+  ...
+`

--- a/yaml_json.go
+++ b/yaml_json.go
@@ -1,0 +1,22 @@
+// +build !yaml
+
+package tap
+
+import (
+	"encoding/json"
+)
+
+// yaml serializes a message to YAML.  This implementation uses JSON,
+// which is a subset of YAML [1] and is implemented by Go's standard
+// library.
+//
+// [1]: http://www.yaml.org/spec/1.2/spec.html#id2759572
+func yaml(message interface{}, prefix string) (marshaled []byte, err error) {
+	marshaled, err = json.MarshalIndent(message, prefix, "  ")
+	if err != nil {
+		return marshaled, err
+	}
+
+	marshaled = append(marshaled, []byte("\n")...)
+	return marshaled, err
+}

--- a/yaml_yaml.go
+++ b/yaml_yaml.go
@@ -1,0 +1,23 @@
+// +build yaml
+
+package tap
+
+import (
+	"bytes"
+
+	goyaml "gopkg.in/yaml.v2"
+)
+
+// yaml serializes a message to YAML.  This implementation uses
+// non-JSON YAML, which has better prove support [1].
+//
+// [1]: https://rt.cpan.org/Public/Bug/Display.html?id=121606
+func yaml(message interface{}, prefix string) (marshaled []byte, err error) {
+	marshaled, err = goyaml.Marshal(message)
+	if err != nil {
+		return marshaled, err
+	}
+
+	marshaled = bytes.Replace(marshaled, []byte("\n"), []byte("\n"+prefix), -1)
+	return marshaled[:len(marshaled)-len(prefix)], err
+}


### PR DESCRIPTION
Docs [here][1].  I've used Go's JSON serializer to avoid external dependencies, since [JSON is a subset of YAML][2].  Prove is currently choking on the results:

```console
$ prove test/yaml/test
test/yaml/test .. Failed 1/2 subtests

Test Summary Report
-------------------
test/yaml/test (Wstat: (none) Tests: 1 Failed: 0)
  Parse errors: Unsupported YAMLish syntax: '{' at /usr/lib64/perl5/5.22.3/TAP/Parser/YAMLish/Reader.pm line 101.

                Bad plan.  You planned 2 tests but ran 1.
Files=1, Tests=1,  0 wallclock secs ( 0.01 usr +  0.00 sys =  0.01 CPU)
Result: FAIL
$ prove --version
TAP::Harness v3.35_01 and Perl v5.22.3
```

but [node-tap][3] parses it fine:

```console
$ tap test/yaml/test
test/yaml/test ........................................ 2/2
total ................................................. 2/2

  2 passing (32.15ms)

  ok

$ tap --version
11.0.0
```

I'll work up a prove ticket once I can find out where to file it.  In the mean time, would you consider switching to node-tap for this project?

[1]: https://testanything.org/tap-version-13-specification.html#yaml-blocks
[2]: http://www.yaml.org/spec/1.2/spec.html#id2759572
[3]: http://www.node-tap.org/